### PR TITLE
[SA] Property based testing for migrations plus made some changes to …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,8 @@ lazy val pureConfigVersion          = "0.15.0"
 lazy val catsEffectTestVersions     = "0.5.3"
 lazy val logForCatVersion           = "1.1.1"
 lazy val testContainersScalaVersion = "0.39.1"
+lazy val scalaCheckVersion          = "1.14.1"
+lazy val scalaTestScalaCheck        = "3.2.5.0"
 
 lazy val applicationSettings = Seq(
   version := "0.1",
@@ -35,11 +37,13 @@ lazy val persistenceService = (project in file("modules/persistenceService"))
     moduleName := "persistenceService",
     Test / fork := true,
     libraryDependencies ++= Seq(
-      "org.tpolecat" %% "doobie-core"                     % doobieVersion,
-      "org.tpolecat" %% "doobie-postgres"                 % doobieVersion,
-      "org.tpolecat" %% "doobie-specs2"                   % doobieVersion,
-      "com.dimafeng" %% "testcontainers-scala-postgresql" % testContainersScalaVersion % "test",
-      "com.dimafeng" %% "testcontainers-scala-scalatest"  % testContainersScalaVersion % "test"
+      "org.tpolecat"      %% "doobie-core"                     % doobieVersion,
+      "org.tpolecat"      %% "doobie-postgres"                 % doobieVersion,
+      "org.tpolecat"      %% "doobie-specs2"                   % doobieVersion,
+      "com.dimafeng"      %% "testcontainers-scala-postgresql" % testContainersScalaVersion % "test",
+      "com.dimafeng"      %% "testcontainers-scala-scalatest"  % testContainersScalaVersion % "test",
+      "org.scalacheck"    %% "scalacheck"                      % scalaCheckVersion          % "test",
+      "org.scalatestplus" %% "scalacheck-1-15"                 % scalaTestScalaCheck        % "test"
     ),
     applicationSettings
   )

--- a/modules/persistenceService/src/main/scala/connectionLayer/DbQueries.scala
+++ b/modules/persistenceService/src/main/scala/connectionLayer/DbQueries.scala
@@ -25,5 +25,5 @@ object DbQueries {
       .query[User]
 
   def remove(userName: UserName): Update0 =
-    sql"delete from userdb where name = $userName".update
+    sql"delete from userdb where username = $userName".update
 }

--- a/modules/persistenceService/src/test/scala/propertyTests/PropertySpec.scala
+++ b/modules/persistenceService/src/test/scala/propertyTests/PropertySpec.scala
@@ -1,0 +1,87 @@
+package propertyTests
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
+import config.{ApplicationConfig, ConnectionUrl, DriverName, PassWord}
+import connectionLayer.{DbConnection, DbQueries}
+import migrations.DbMigrations
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatestplus.scalacheck._
+import org.scalatest.matchers.should.Matchers
+import persistenceModel.{Id, Name, User, UserName}
+import config.{User => ConfigUser}
+import java.util.UUID
+import doobie.implicits._
+import org.scalacheck.{Arbitrary, Gen}
+
+class PropertySpec
+    extends AsyncFreeSpec
+    with AsyncIOSpec
+    with ScalaCheckDrivenPropertyChecks
+    with ForAllTestContainer
+    with Matchers {
+
+  override val container: PostgreSQLContainer = PostgreSQLContainer()
+
+  lazy val driverName    = DriverName(container.driverClassName)
+  lazy val connectionUrl = ConnectionUrl(container.jdbcUrl)
+  lazy val user          = ConfigUser(container.username)
+  lazy val password      = PassWord(container.password)
+
+  implicit val nameArb: Arbitrary[Name]         = Arbitrary(Gen.identifier.map(Name(_)))
+  implicit val userNameArb: Arbitrary[UserName] = Arbitrary(Gen.identifier.map(UserName(_)))
+
+  "Migration" - {
+
+    "after creating user table" - {
+      "should allows user to be inserted into userdb" in {
+
+        val migrationExecuted = DbMigrations
+          .migrate[IO](ApplicationConfig(driverName, connectionUrl, user, password))
+          .map(_.migrationsExecuted)
+
+        forAll { (id: UUID, name: Name, userName: UserName) =>
+          val theUserID = Id(id)
+          val theUser   = User(theUserID, name, userName)
+
+          val result: IO[Option[User]] = for {
+            _ <- migrationExecuted
+            dbQueries = new DbQueries[IO]
+            dbConnection = new DbConnection[IO](
+              ApplicationConfig(driverName, connectionUrl, user, password)
+            )
+            _         <- dbQueries.insert(theUser).transact(dbConnection.connection)
+            foundUser <- dbQueries.find(theUser.userName).transact(dbConnection.connection)
+          } yield foundUser
+
+          result.asserting(e => e shouldBe (Some(theUser))).unsafeRunSync()
+
+        }
+      }
+
+      "should allows user to be deleted from the userdb" in {
+        val migrationExecuted = DbMigrations
+          .migrate[IO](ApplicationConfig(driverName, connectionUrl, user, password))
+          .map(_.migrationsExecuted)
+
+        forAll { (id: UUID, name: Name, userName: UserName) =>
+          val theUserID = Id(id)
+          val theUser   = User(theUserID, name, userName)
+
+          val result: IO[Option[User]] = for {
+            _ <- migrationExecuted
+            dbQueries = new DbQueries[IO]
+            dbConnection = new DbConnection[IO](
+              ApplicationConfig(driverName, connectionUrl, user, password)
+            )
+            _         <- dbQueries.insert(theUser).transact(dbConnection.connection)
+            _         <- dbQueries.remove(theUser.userName).transact(dbConnection.connection)
+            foundUser <- dbQueries.find(theUser.userName).transact(dbConnection.connection)
+          } yield foundUser
+
+          result.asserting(e => e shouldBe None).unsafeRunSync()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Implemented property testing for the queries inside the test container
- Made a quick change to the `remove` query as it was using name instead for `username`
- Wanted to move the migration into a `beforeEach` and `afterEach` fixture but that is taking a bit more time with `scalaTest` so I thought I should raise an initial PR and then continue to look into that.